### PR TITLE
edtlib: fix possible AttributeError in Property.description

### DIFF
--- a/src/devicetree/edtlib.py
+++ b/src/devicetree/edtlib.py
@@ -1635,7 +1635,9 @@ class Property:
     @property
     def description(self):
         "See the class docstring"
-        return self.spec.description.strip()
+        if self.spec.description is not None:
+            return self.spec.description.strip()
+        return None
 
     @property
     def type(self):


### PR DESCRIPTION
Attempting to access the property `Property.description` when `Property.spec.description` is `None` would raise:
```
AttributeError: 'NoneType' object has no attribute 'strip'.
```

Known affected properties:
+ `compatible` for nodes such as `/`, `/soc`, `/soc/timer@e000e010`, `/leds`, `/pwmleds` 
+ `reg`        for nodes such as `/soc/timer@e000e010`
+ `status`     for nodes such as `/soc/timer@e000e010`
+ `gpios`      for nodes such as `/leds/led_0`, `/buttons/button_0`
+ `pwms`       for nodes such as `/pwmleds/pwm_led_0`

This patch checks the `PropertySpec.description` attribute before calling `strip()`.

Thanks.

--
chris