### PR TITLE
edtlib: fix possible TypeError in Binding.__repr__()

### DIFF
--- a/src/devicetree/edtlib.py
+++ b/src/devicetree/edtlib.py
@@ -1794,7 +1794,8 @@ class Binding:
             compat = f" for compatible '{self.compatible}'"
         else:
             compat = ""
-        return f"<Binding {os.path.basename(self.path)}" + compat + ">"
+        basename = os.path.basename(self.path) if self.path is not None else ""
+        return f"<Binding {basename}" + compat + ">"
 
     @property
     def description(self):


### PR DESCRIPTION
Calling `Binding.__repr__()` when the attribute `Binding.path` is `None` would raise:
```
TypeError:` expected str, bytes or os.PathLike object, not NoneType.
```

Known affected bindings include bindings for properties such as `compatible`, `reg`, `status`.

We should check the `Binding.path` attribute before calling `os.path.basename()`.

Thanks.

--
chris